### PR TITLE
Package name should not be in quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Similarly, the npm package [React Devicon](https://www.npmjs.com/package/react-d
 ## Installation
 Using NPM:
 
-`npm install 'devicon-react' --save`
+`npm install devicon-react --save`
 
 Using Yarn:
 


### PR DESCRIPTION
When copying the command from readme above, package is not saved as meta in `package.json` file of a project.